### PR TITLE
Split "BlackBox" to "Black Box" like upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenInBlackBox
 
-<p>Simple script to open my favorite terminal <a href="https://gitlab.gnome.org/raggesilver/blackbox">BlackBox</a> from Nautilus (Gnome Files) Menu</p>
+<p>Simple script to open my favorite terminal <a href="https://gitlab.gnome.org/raggesilver/blackbox">Black Box</a> from Nautilus (Gnome Files) Menu</p>
 ---
 <p align="center">
   <img src="https://raw.githubusercontent.com/phucnoob/OpenInBlackBox/main/preview.png" />

--- a/nautilus-open-in-blackbox.py
+++ b/nautilus-open-in-blackbox.py
@@ -64,12 +64,12 @@ class BlackBoxNautilus(GObject.GObject, Nautilus.MenuProvider):
         return menu
 
     def _create_nautilus_item(self, dir_path: str) -> Nautilus.MenuItem:
-        """Creates the 'Open In BlackBox' menu item."""
+        """Creates the 'Open In Black Box' menu item."""
 
         item = Nautilus.MenuItem(
             name="BlackBoxNautilus::open_in_blackbox",
-            label=gettext("Open in BlackBox"),
-            tip=gettext("Open this folder/file in BlackBox Terminal"),
+            label=gettext("Open in Black Box"),
+            tip=gettext("Open this folder/file in Black Box Terminal"),
         )
         print(f"Created item with path {dir_path}")
 
@@ -82,7 +82,7 @@ class BlackBoxNautilus(GObject.GObject, Nautilus.MenuProvider):
         return shutil.which("blackbox") == "/usr/bin/blackbox"
 
     def _nautilus_run(self, menu, path):
-        """'Open with BlackBox 's menu item callback."""
+        """'Open with Black Box 's menu item callback."""
         print("Openning:", path)
         args = None
         if self.is_native():


### PR DESCRIPTION
The Black Box project has its name split into two separate words, "Black Box" instead of "BlackBox". This pull request is just to make it consistent with upstream.