### PR TITLE
Select 'default' when language is not in TRANSLATIONS

### DIFF
--- a/nautilus-open-in-blackbox.py
+++ b/nautilus-open-in-blackbox.py
@@ -61,8 +61,9 @@ class OpenBlackboxTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
         """Creates the 'Open In Black Box' menu item."""
 
         lang = locale.getlocale()[0].split("_")[0]  # en, fr, vi...
-        label = TRANSLATIONS[lang]["label"]
-        tip = TRANSLATIONS[lang]["tip"]
+        translation = TRANSLATIONS.get(lang, TRANSLATIONS["default"])
+        label = translation["label"]
+        tip = translation["tip"]
 
         item = Nautilus.MenuItem(
             name="BlackBoxNautilus::open_in_blackbox1",
@@ -78,8 +79,9 @@ class OpenBlackboxTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
     ) -> Nautilus.MenuItem:
         """Creates the 'Open In Black Box' menu item."""
         lang = locale.getlocale()[0].split("_")[0]  # en, fr, vi...
-        label = TRANSLATIONS[lang]["label"]
-        tip = TRANSLATIONS[lang]["tip"]
+        translation = TRANSLATIONS.get(lang, TRANSLATIONS["default"])
+        label = translation["label"]
+        tip = translation["tip"]
 
         item = Nautilus.MenuItem(
             name="BlackBoxNautilus::open_in_blackbox2",

--- a/nautilus-open-in-blackbox.py
+++ b/nautilus-open-in-blackbox.py
@@ -62,13 +62,11 @@ class OpenBlackboxTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
 
         lang = locale.getlocale()[0].split("_")[0]  # en, fr, vi...
         translation = TRANSLATIONS.get(lang, TRANSLATIONS["default"])
-        label = translation["label"]
-        tip = translation["tip"]
 
         item = Nautilus.MenuItem(
             name="BlackBoxNautilus::open_in_blackbox1",
-            label=label,
-            tip=tip,
+            label=translation["label"],
+            tip=translation["tip"],
         )
 
         item.connect("activate", self._open_terminal, fileInfo)
@@ -80,13 +78,11 @@ class OpenBlackboxTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
         """Creates the 'Open In Black Box' menu item."""
         lang = locale.getlocale()[0].split("_")[0]  # en, fr, vi...
         translation = TRANSLATIONS.get(lang, TRANSLATIONS["default"])
-        label = translation["label"]
-        tip = translation["tip"]
 
         item = Nautilus.MenuItem(
             name="BlackBoxNautilus::open_in_blackbox2",
-            label=label,
-            tip=tip,
+            label=translation["label"],
+            tip=translation["tip"],
         )
 
         item.connect("activate", self._open_terminal, fileInfo)


### PR DESCRIPTION
Currently if lang is not in the TRANSLATIONS dict it ignores "default" and terminates. This simply fix should solve that